### PR TITLE
Set environment variables for deployment in GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,10 +3,17 @@ on:
   push:
     branches:
       - "main"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   Lint:
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_IS_DEPLOYMENT: true
+      NEXT_PUBLIC_NETWORK_TYPE: "testnet"
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Added NEXT_PUBLIC_IS_DEPLOYMENT and NEXT_PUBLIC_NETWORK_TYPE to the Lint job in check.yml. This ensures the correct environment configuration for testing on the "testnet" network during CI/CD workflows.