### PR TITLE
fix: add padding to tally bar if yes is present but below a threshold.

### DIFF
--- a/src/features/governance/components/ProposalTallyBar.tsx
+++ b/src/features/governance/components/ProposalTallyBar.tsx
@@ -33,7 +33,9 @@ export const ProposalTallyBar: React.FC<ProposalTallyBarProps> = ({
           {yesPercentage > 0 && <span className="text-success">YES</span>}
           {abstainPercentage > 0 && (
             <span
-              className="absolute text-[#949494]"
+              className={`absolute text-[#949494] ${
+                scaledYes > 8 ? "" : "px-10"
+              }`}
               style={{ left: `${scaledYes}%` }}
             >
               ABSTAIN
@@ -61,7 +63,10 @@ export const ProposalTallyBar: React.FC<ProposalTallyBarProps> = ({
         <div className="font-['Akkurat LL'] mb-4 flex text-sm font-bold leading-none text-white">
           {yesPercentage > 0 && <span>{yesPercentage.toFixed(2)}%</span>}
           {abstainPercentage > 0 && (
-            <span className="absolute" style={{ left: `${scaledYes}%` }}>
+            <span
+              className={`absolute ${scaledYes > 8 ? "" : "px-10"}`}
+              style={{ left: `${scaledYes}%` }}
+            >
               {abstainPercentage.toFixed(2)}%
             </span>
           )}


### PR DESCRIPTION
- [x] add padding to Abstain if "yes" votes are below threshold to push abstain label.

## Before
<img width="592" alt="image" src="https://github.com/user-attachments/assets/75808948-2f22-402a-a140-22670ec3760d">


## After
<img width="1188" alt="image" src="https://github.com/user-attachments/assets/84588424-ab90-4da9-94b3-733ff0fc0a9b">


