### PR TITLE
feat: update apr calc

### DIFF
--- a/src/features/staking/context/selectors.ts
+++ b/src/features/staking/context/selectors.ts
@@ -118,5 +118,7 @@ export const getAllValidators = (
 
 export const getAPR = (state: StakingState) =>
   state.inflation && state.communityTax
-    ? new BigNumber(state.inflation).minus(state.communityTax)
+    ? new BigNumber(state.inflation).times(
+        new BigNumber(1).minus(new BigNumber(state.communityTax)),
+      )
     : null;


### PR DESCRIPTION
# Update APR Calc 
This PR fixes the APR calc such that the community tax is taken from the inflated tokens instead of against all tokens

## Checklist
- [x] Update `getAPR` selector to reflect `distribution = inflation_rate * (1- community_tax)`

Resolves: https://linear.app/burnt/issue/ENG-777/discrepancy-in-apr-values-on-staking-dashboard-and-mintscankeplr
