### PR TITLE
Enhance unbonding time formatting with hours and minutes

### DIFF
--- a/.changeset/blue-lions-swim.md
+++ b/.changeset/blue-lions-swim.md
@@ -1,0 +1,5 @@
+---
+"abstraxion-staking-poc": patch
+---
+
+Enhance unbonding time formatting with hours and minutes.

--- a/src/features/staking/lib/formatters.ts
+++ b/src/features/staking/lib/formatters.ts
@@ -94,6 +94,18 @@ export const formatUnbondingCompletionTime = (completionTime: number) => {
   const now = Date.now();
   const remainingMilliseconds = completionTimestamp - now;
 
+  const month = new Date(completionTimestamp).toLocaleString("en-US", {
+    month: "short",
+  });
+
+  const day = new Date(completionTimestamp).getDate();
+  const year = new Date(completionTimestamp).getFullYear();
+
+  // Handle case where completion time has already passed
+  if (remainingMilliseconds <= 0) {
+    return `Completed on ${month} ${day} ${year}`;
+  }
+
   const remainingDays = Math.floor(
     remainingMilliseconds / (1000 * 60 * 60 * 24),
   );
@@ -105,13 +117,6 @@ export const formatUnbondingCompletionTime = (completionTime: number) => {
   const remainingMinutes = Math.floor(
     (remainingMilliseconds % (1000 * 60 * 60)) / (1000 * 60),
   );
-
-  const month = new Date(completionTimestamp).toLocaleString("en-US", {
-    month: "short",
-  });
-
-  const day = new Date(completionTimestamp).getDate();
-  const year = new Date(completionTimestamp).getFullYear();
 
   let timeDisplay = "";
 

--- a/src/features/staking/lib/formatters.ts
+++ b/src/features/staking/lib/formatters.ts
@@ -91,9 +91,19 @@ export const formatXionToUSD = (
 
 export const formatUnbondingCompletionTime = (completionTime: number) => {
   const completionTimestamp = completionTime * 1000;
+  const now = Date.now();
+  const remainingMilliseconds = completionTimestamp - now;
 
   const remainingDays = Math.floor(
-    (completionTimestamp - Date.now()) / (1000 * 60 * 60 * 24),
+    remainingMilliseconds / (1000 * 60 * 60 * 24),
+  );
+
+  const remainingHours = Math.floor(
+    (remainingMilliseconds % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+  );
+
+  const remainingMinutes = Math.floor(
+    (remainingMilliseconds % (1000 * 60 * 60)) / (1000 * 60),
   );
 
   const month = new Date(completionTimestamp).toLocaleString("en-US", {
@@ -103,7 +113,15 @@ export const formatUnbondingCompletionTime = (completionTime: number) => {
   const day = new Date(completionTimestamp).getDate();
   const year = new Date(completionTimestamp).getFullYear();
 
-  return `in ${remainingDays} day${remainingDays === 1 ? "" : "s"}, ${month} ${day} ${year}`;
+  let timeDisplay = "";
+
+  if (remainingDays > 0) {
+    timeDisplay = `${remainingDays} day${remainingDays === 1 ? "" : "s"}`;
+  } else {
+    timeDisplay = `${remainingHours} hour${remainingHours === 1 ? "" : "s"}, ${remainingMinutes} minute${remainingMinutes === 1 ? "" : "s"}`;
+  }
+
+  return `in ${timeDisplay}, ${month} ${day} ${year}`;
 };
 
 export const formatAPR = (apr: BigNumber | null) => {


### PR DESCRIPTION
Previously, only the remaining days were shown for unbonding completion time. This update adds support for displaying hours and minutes when less than a day remains, improving user clarity on shorter timeframes.