### PR TITLE
fix: show error indication for APR when API calls fail

### DIFF
--- a/.changeset/spotty-days-happen.md
+++ b/.changeset/spotty-days-happen.md
@@ -1,0 +1,5 @@
+---
+"xion-staking": patch
+---
+
+Fix APR display to show error indication instead of fallback values when API calls fail

--- a/src/features/staking/context/actions.ts
+++ b/src/features/staking/context/actions.ts
@@ -73,8 +73,14 @@ export const fetchStakingDataAction = async (staking: StakingContextType) => {
     });
 
     staking.dispatch(setPool(pool));
-    staking.dispatch(setInflation(inflation.toString()));
-    staking.dispatch(setCommunityTax(communityTax.toString()));
+
+    if (inflation !== null) {
+      staking.dispatch(setInflation(inflation.toString()));
+    }
+
+    if (communityTax !== null) {
+      staking.dispatch(setCommunityTax(communityTax.toString()));
+    }
 
     staking.dispatch(setIsInfoLoading(false));
   } catch (error) {

--- a/src/features/staking/lib/core/base.ts
+++ b/src/features/staking/lib/core/base.ts
@@ -131,7 +131,7 @@ export const getInflation = async () => {
   } catch (error) {
     console.error("Failed to fetch inflation:", error);
 
-    return 0.42;
+    return null;
   }
 };
 
@@ -154,6 +154,6 @@ export const getDistributionParams = async () => {
   } catch (error) {
     console.error("Failed to fetch distribution params:", error);
 
-    return 0.02;
+    return null;
   }
 };

--- a/src/features/staking/lib/formatters.ts
+++ b/src/features/staking/lib/formatters.ts
@@ -131,7 +131,7 @@ export const formatUnbondingCompletionTime = (completionTime: number) => {
 
 export const formatAPR = (apr: BigNumber | null) => {
   if (!apr) {
-    return "-";
+    return "—";
   }
 
   return `${apr.times(100).toFixed(2)}%`;


### PR DESCRIPTION
- Remove fallback values (42% inflation, 2% community tax) from API error handlers
- Display em dash (—) instead of incorrect APR when data fails to load
- Prevent misleading APR values from being shown to users

![image](https://github.com/user-attachments/assets/d004ca90-818e-488d-8921-d219ef33f3e4)
