### PR TITLE
chore: update burnt-labs packages to latest versions

### DIFF
--- a/.changeset/whole-sheep-rest.md
+++ b/.changeset/whole-sheep-rest.md
@@ -1,0 +1,9 @@
+---
+"xion-staking": patch
+---
+
+Update burnt-labs packages to latest versions
+
+- @burnt-labs/abstraxion: 1.0.0-alpha.57 → 1.0.0-alpha.66
+- @burnt-labs/constants: 0.1.0-alpha.15 → 0.1.0-alpha.18
+- @burnt-labs/ui: 0.1.0-alpha.7 → 0.1.0-alpha.17

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 *.svg
 .yarn
 worker-configuration.d.ts
+.changeset

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "xion-staking",
       "version": "0.1.0",
       "dependencies": {
-        "@burnt-labs/abstraxion": "^1.0.0-alpha.57",
-        "@burnt-labs/constants": "^0.1.0-alpha.15",
-        "@burnt-labs/ui": "^0.1.0-alpha.7",
+        "@burnt-labs/abstraxion": "^1.0.0-alpha.66",
+        "@burnt-labs/constants": "^0.1.0-alpha.18",
+        "@burnt-labs/ui": "^0.1.0-alpha.17",
         "@chain-registry/types": "^0.50.56",
         "@cosmjs/cosmwasm-stargate": "^0.32.4",
         "@cosmjs/proto-signing": "^0.32.4",
@@ -368,22 +368,22 @@
       }
     },
     "node_modules/@burnt-labs/abstraxion": {
-      "version": "1.0.0-alpha.57",
-      "resolved": "https://registry.npmjs.org/@burnt-labs/abstraxion/-/abstraxion-1.0.0-alpha.57.tgz",
-      "integrity": "sha512-HtyzQDFWJdGSsSmlH8yhEFgOk0OvJ6C9l9fCu2oiLPNUzcFoAko+bccBToSxB2JToGtWlbWvV8q1JKVGbWHRMg==",
+      "version": "1.0.0-alpha.66",
+      "resolved": "https://registry.npmjs.org/@burnt-labs/abstraxion/-/abstraxion-1.0.0-alpha.66.tgz",
+      "integrity": "sha512-ZuE8az0r4o27stbPDDx3VjUEkigWpLqhfqU+T5gQUnJVWReL4U1Pqq1TsSUZDkHT/J0RT7enKj+RZkNhP/nNxw==",
+      "license": "MIT",
       "dependencies": {
-        "@burnt-labs/abstraxion-core": "1.0.0-alpha.52",
-        "@burnt-labs/constants": "0.1.0-alpha.15",
-        "@burnt-labs/signers": "0.1.0-alpha.13",
-        "@burnt-labs/ui": "0.1.0-alpha.16",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/cosmwasm-stargate": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stargate": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
+        "@burnt-labs/abstraxion-core": "1.0.0-alpha.59",
+        "@burnt-labs/constants": "0.1.0-alpha.18",
+        "@burnt-labs/ui": "0.1.0-alpha.17",
+        "@cosmjs/amino": "^0.33.1",
+        "@cosmjs/cosmwasm-stargate": "^0.33.1",
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/proto-signing": "^0.33.1",
+        "@cosmjs/stargate": "^0.33.1",
+        "@cosmjs/tendermint-rpc": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
         "@types/react-dom": "^18.2.18",
         "cosmjs-types": "^0.9.0",
         "jose": "^5.1.3"
@@ -394,96 +394,337 @@
       }
     },
     "node_modules/@burnt-labs/abstraxion-core": {
-      "version": "1.0.0-alpha.52",
-      "resolved": "https://registry.npmjs.org/@burnt-labs/abstraxion-core/-/abstraxion-core-1.0.0-alpha.52.tgz",
-      "integrity": "sha512-3AZOJeHbtHMnExijDpu7j1s1z5BXgaM2c1daqOTDaHtvI4iEcZxM388ZqafLOU2kk8KeIdIC0t4QTJDPgpk7tg==",
+      "version": "1.0.0-alpha.59",
+      "resolved": "https://registry.npmjs.org/@burnt-labs/abstraxion-core/-/abstraxion-core-1.0.0-alpha.59.tgz",
+      "integrity": "sha512-ci0NujNd1lVWV75BAOFxx6IXoGrwdrcbg6yOhPwdyIbt7wEBJ/TzKcy5mVgdy/gnqlmD1/wsOTNTP+2njNZSgQ==",
+      "license": "MIT",
       "dependencies": {
-        "@burnt-labs/constants": "0.1.0-alpha.15",
-        "@burnt-labs/signers": "0.1.0-alpha.13",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/cosmwasm-stargate": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stargate": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
+        "@burnt-labs/constants": "0.1.0-alpha.18",
+        "@cosmjs/amino": "^0.33.1",
+        "@cosmjs/cosmwasm-stargate": "^0.33.1",
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/proto-signing": "^0.33.1",
+        "@cosmjs/stargate": "^0.33.1",
+        "@cosmjs/tendermint-rpc": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "base64-js": "^1.5.1",
         "cosmjs-types": "^0.9.0",
         "jose": "^5.1.3"
       }
     },
-    "node_modules/@burnt-labs/constants": {
-      "version": "0.1.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@burnt-labs/constants/-/constants-0.1.0-alpha.15.tgz",
-      "integrity": "sha512-MFgeuodJrV1tjeAjIKejVALSMzr/xGeTCrw8akqWa9y2KvleOy3516m1j7aOwkWSoInPhp9uZYzOAwgnAVBdpQ=="
-    },
-    "node_modules/@burnt-labs/signers": {
-      "version": "0.1.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@burnt-labs/signers/-/signers-0.1.0-alpha.13.tgz",
-      "integrity": "sha512-89O2oWpR+qvZs13vDB1aibp0FkkPEQf9NUVwVe/pN/JnuhPKWW4a1rUB6/qEkcEAMkQFsT7hyaqhRzx2hbfC6Q==",
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/amino": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.33.1.tgz",
+      "integrity": "sha512-WfWiBf2EbIWpwKG9AOcsIIkR717SY+JdlXM/SL/bI66BdrhniAF+/ZNis9Vo9HF6lP2UU5XrSmFA4snAvEgdrg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/client": "^3.8.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/cosmwasm-stargate": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stargate": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@protobuf-ts/runtime": "^2.9.3",
-        "bech32": "^2.0.0",
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/cosmwasm-stargate": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.33.1.tgz",
+      "integrity": "sha512-bsEH8FmDHE0zc9WmJuyYEruV/HP7DU98FLP/BMxb1Egk/weH304m1AuIdibdVfFZKYVNq6PkD8+Xvg23qnecIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.33.1",
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/proto-signing": "^0.33.1",
+        "@cosmjs/stargate": "^0.33.1",
+        "@cosmjs/tendermint-rpc": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
         "cosmjs-types": "^0.9.0",
-        "stytch": "^9.0.6"
+        "pako": "^2.0.2"
       }
     },
-    "node_modules/@burnt-labs/signers/node_modules/@apollo/client": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.1.tgz",
-      "integrity": "sha512-HaAt62h3jNUXpJ1v5HNgUiCzPP1c5zc2Q/FeTb2cTk/v09YlhoqKKHQFJI7St50VCJ5q8JVIc03I5bRcBrQxsg==",
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/crypto": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.33.1.tgz",
+      "integrity": "sha512-U4kGIj/SNBzlb2FGgA0sMR0MapVgJUg8N+oIAiN5+vl4GZ3aefmoL1RDyTrFS/7HrB+M+MtHsxC0tvEu4ic/zA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/caches": "^1.0.0",
-        "@wry/equality": "^0.5.6",
-        "@wry/trie": "^0.5.0",
-        "graphql-tag": "^2.12.6",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.18.0",
-        "prop-types": "^15.7.2",
-        "rehackt": "^0.1.0",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.3",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.5"
-      },
-      "peerDependencies": {
-        "graphql": "^15.0.0 || ^16.0.0",
-        "graphql-ws": "^5.5.5 || ^6.0.3",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
-        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
-      },
-      "peerDependenciesMeta": {
-        "graphql-ws": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "subscriptions-transport-ws": {
-          "optional": true
-        }
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.6.1",
+        "libsodium-wrappers-sumo": "^0.7.11"
       }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/encoding": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.33.1.tgz",
+      "integrity": "sha512-nuNxf29fUcQE14+1p//VVQDwd1iau5lhaW/7uMz7V2AH3GJbFJoJVaKvVyZvdFk+Cnu+s3wCqgq4gJkhRCJfKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/json-rpc": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.33.1.tgz",
+      "integrity": "sha512-T6VtWzecpmuTuMRGZWuBYHsMF/aznWCYUt/cGMWNSz7DBPipVd0w774PKpxXzpEbyt5sr61NiuLXc+Az15S/Cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/stream": "^0.33.1",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/math": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.33.1.tgz",
+      "integrity": "sha512-ytGkWdKFCPiiBU5eqjHNd59djPpIsOjbr2CkNjlnI1Zmdj+HDkSoD9MUGpz9/RJvRir5IvsXqdE05x8EtoQkJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/proto-signing": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.33.1.tgz",
+      "integrity": "sha512-Sv4W+MxX+0LVnd+2rU4Fw1HRsmMwSVSYULj7pRkij3wnPwUlTVoJjmKFgKz13ooIlfzPrz/dnNjGp/xnmXChFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.33.1",
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/socket": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.33.1.tgz",
+      "integrity": "sha512-KzAeorten6Vn20sMiM6NNWfgc7jbyVo4Zmxev1FXa5EaoLCZy48cmT3hJxUJQvJP/lAy8wPGEjZ/u4rmF11x9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/stream": "^0.33.1",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/stargate": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.33.1.tgz",
+      "integrity": "sha512-CnJ1zpSiaZgkvhk+9aTp5IPmgWn2uo+cNEBN8VuD9sD6BA0V4DMjqe251cNFLiMhkGtiE5I/WXFERbLPww3k8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/proto-signing": "^0.33.1",
+        "@cosmjs/stream": "^0.33.1",
+        "@cosmjs/tendermint-rpc": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/stream": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.33.1.tgz",
+      "integrity": "sha512-bMUvEENjeQPSTx+YRzVsWT1uFIdHRcf4brsc14SOoRQ/j5rOJM/aHfsf/BmdSAnYbdOQ3CMKj/8nGAQ7xUdn7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.33.1.tgz",
+      "integrity": "sha512-22klDFq2MWnf//C8+rZ5/dYatr6jeGT+BmVbutXYfAK9fmODbtFcumyvB6uWaEORWfNukl8YK1OLuaWezoQvxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/json-rpc": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/socket": "^0.33.1",
+        "@cosmjs/stream": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "axios": "^1.6.0",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion-core/node_modules/@cosmjs/utils": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.33.1.tgz",
+      "integrity": "sha512-UnLHDY6KMmC+UXf3Ufyh+onE19xzEXjT4VZ504Acmk4PXxqyvG4cCPprlKUFnGUX7f0z8Or9MAOHXBx41uHBcg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/amino": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.33.1.tgz",
+      "integrity": "sha512-WfWiBf2EbIWpwKG9AOcsIIkR717SY+JdlXM/SL/bI66BdrhniAF+/ZNis9Vo9HF6lP2UU5XrSmFA4snAvEgdrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/cosmwasm-stargate": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.33.1.tgz",
+      "integrity": "sha512-bsEH8FmDHE0zc9WmJuyYEruV/HP7DU98FLP/BMxb1Egk/weH304m1AuIdibdVfFZKYVNq6PkD8+Xvg23qnecIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.33.1",
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/proto-signing": "^0.33.1",
+        "@cosmjs/stargate": "^0.33.1",
+        "@cosmjs/tendermint-rpc": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "cosmjs-types": "^0.9.0",
+        "pako": "^2.0.2"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/crypto": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.33.1.tgz",
+      "integrity": "sha512-U4kGIj/SNBzlb2FGgA0sMR0MapVgJUg8N+oIAiN5+vl4GZ3aefmoL1RDyTrFS/7HrB+M+MtHsxC0tvEu4ic/zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.6.1",
+        "libsodium-wrappers-sumo": "^0.7.11"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/encoding": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.33.1.tgz",
+      "integrity": "sha512-nuNxf29fUcQE14+1p//VVQDwd1iau5lhaW/7uMz7V2AH3GJbFJoJVaKvVyZvdFk+Cnu+s3wCqgq4gJkhRCJfKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/json-rpc": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.33.1.tgz",
+      "integrity": "sha512-T6VtWzecpmuTuMRGZWuBYHsMF/aznWCYUt/cGMWNSz7DBPipVd0w774PKpxXzpEbyt5sr61NiuLXc+Az15S/Cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/stream": "^0.33.1",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/math": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.33.1.tgz",
+      "integrity": "sha512-ytGkWdKFCPiiBU5eqjHNd59djPpIsOjbr2CkNjlnI1Zmdj+HDkSoD9MUGpz9/RJvRir5IvsXqdE05x8EtoQkJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/proto-signing": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.33.1.tgz",
+      "integrity": "sha512-Sv4W+MxX+0LVnd+2rU4Fw1HRsmMwSVSYULj7pRkij3wnPwUlTVoJjmKFgKz13ooIlfzPrz/dnNjGp/xnmXChFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.33.1",
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/socket": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.33.1.tgz",
+      "integrity": "sha512-KzAeorten6Vn20sMiM6NNWfgc7jbyVo4Zmxev1FXa5EaoLCZy48cmT3hJxUJQvJP/lAy8wPGEjZ/u4rmF11x9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/stream": "^0.33.1",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/stargate": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.33.1.tgz",
+      "integrity": "sha512-CnJ1zpSiaZgkvhk+9aTp5IPmgWn2uo+cNEBN8VuD9sD6BA0V4DMjqe251cNFLiMhkGtiE5I/WXFERbLPww3k8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/proto-signing": "^0.33.1",
+        "@cosmjs/stream": "^0.33.1",
+        "@cosmjs/tendermint-rpc": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/stream": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.33.1.tgz",
+      "integrity": "sha512-bMUvEENjeQPSTx+YRzVsWT1uFIdHRcf4brsc14SOoRQ/j5rOJM/aHfsf/BmdSAnYbdOQ3CMKj/8nGAQ7xUdn7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.33.1.tgz",
+      "integrity": "sha512-22klDFq2MWnf//C8+rZ5/dYatr6jeGT+BmVbutXYfAK9fmODbtFcumyvB6uWaEORWfNukl8YK1OLuaWezoQvxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/json-rpc": "^0.33.1",
+        "@cosmjs/math": "^0.33.1",
+        "@cosmjs/socket": "^0.33.1",
+        "@cosmjs/stream": "^0.33.1",
+        "@cosmjs/utils": "^0.33.1",
+        "axios": "^1.6.0",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@burnt-labs/abstraxion/node_modules/@cosmjs/utils": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.33.1.tgz",
+      "integrity": "sha512-UnLHDY6KMmC+UXf3Ufyh+onE19xzEXjT4VZ504Acmk4PXxqyvG4cCPprlKUFnGUX7f0z8Or9MAOHXBx41uHBcg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@burnt-labs/constants": {
+      "version": "0.1.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@burnt-labs/constants/-/constants-0.1.0-alpha.18.tgz",
+      "integrity": "sha512-cyEEs6ZN4ZwvwaFRVXgZqk6SlF8DsiHCBScdi7WDgJ42m09KUeqbKXj07OrgVugbvo/IFBDi5BSpdMrWezay3g==",
+      "license": "MIT"
     },
     "node_modules/@burnt-labs/ui": {
-      "version": "0.1.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/@burnt-labs/ui/-/ui-0.1.0-alpha.16.tgz",
-      "integrity": "sha512-Por7p5PqrS63cfiivfKEQQNNTV3k6kCoitoo8NPtftDRXZJ9h2gtv9DimSB0d780+hU1VnpKhFn82xdH0IhFsg==",
+      "version": "0.1.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/@burnt-labs/ui/-/ui-0.1.0-alpha.17.tgz",
+      "integrity": "sha512-NlaTBAdEnEBv6A4PvxRiiYRtmQrU7QwR9RyrPHeqseumTw3qqaq4k7Gged2r0yQgd16ELThp7C24NkphroTy0g==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-popover": "^1.0.7",
@@ -601,12 +842,6 @@
         "big-integer": "^1.6.48",
         "utility-types": "^3.10.0"
       }
-    },
-    "node_modules/@chain-registry/keplr/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
     },
     "node_modules/@chain-registry/types": {
       "version": "0.50.71",
@@ -1236,11 +1471,6 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "node_modules/@cosmjs/encoding/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
     "node_modules/@cosmjs/json-rpc": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
@@ -1632,11 +1862,6 @@
       "dependencies": {
         "long": "^4.0.0"
       }
-    },
-    "node_modules/@cosmsnap/snapper/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2104,6 +2329,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -2225,14 +2451,6 @@
       "integrity": "sha512-SwPWfeRa5veb1hOIBMdzI+73te5puUBHmqqaF1Bu7FjvxlYSz/kJcZKSa9Cg60zL0uRNeJL2SbRxV6Jp6Q1nFQ==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -3491,11 +3709,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
-    },
-    "node_modules/@protobuf-ts/runtime": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
-      "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -7285,50 +7498,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
-    "node_modules/@wry/caches": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
-      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/context": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
-      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/equality": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
-      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/trie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
-      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/abi-wan-kanabi": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.2.4.tgz",
@@ -7891,9 +8060,10 @@
       "dev": true
     },
     "node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
     },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
@@ -10875,29 +11045,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/graphql": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/h3": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.14.0.tgz",
@@ -11038,14 +11185,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -11788,6 +11927,7 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
       "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -12619,17 +12759,6 @@
       "dev": true,
       "bin": {
         "opener": "bin/opener-bin.js"
-      }
-    },
-    "node_modules/optimism": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
-      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
-      "dependencies": {
-        "@wry/caches": "^1.0.0",
-        "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.5.0",
-        "tslib": "^2.3.0"
       }
     },
     "node_modules/optionator": {
@@ -13807,23 +13936,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rehackt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
-      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -14684,26 +14796,6 @@
         }
       }
     },
-    "node_modules/stytch": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/stytch/-/stytch-9.1.0.tgz",
-      "integrity": "sha512-xEh538ESOg1CjRha7fxiVflli6hDoKATPDwP9j3+XfwsdaAg11B/kwSu9SU8dPVg8WRZTxoPHObWpJkjLY90LA==",
-      "dependencies": {
-        "jose": "^4.14.6",
-        "undici": "^5.25.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/stytch/node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -14748,14 +14840,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/tabbable": {
@@ -14977,17 +15061,6 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
-    },
-    "node_modules/ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
@@ -15314,18 +15387,6 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -16709,19 +16770,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "dependencies": {
-        "zen-observable": "0.8.15"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "deploy:testnet": "wrangler pages deploy --env testnet"
   },
   "dependencies": {
-    "@burnt-labs/abstraxion": "^1.0.0-alpha.57",
-    "@burnt-labs/constants": "^0.1.0-alpha.15",
-    "@burnt-labs/ui": "^0.1.0-alpha.7",
+    "@burnt-labs/abstraxion": "^1.0.0-alpha.66",
+    "@burnt-labs/constants": "^0.1.0-alpha.18",
+    "@burnt-labs/ui": "^0.1.0-alpha.17",
     "@chain-registry/types": "^0.50.56",
     "@cosmjs/cosmwasm-stargate": "^0.32.4",
     "@cosmjs/proto-signing": "^0.32.4",


### PR DESCRIPTION
## Summary
- Updated @burnt-labs/abstraxion from 1.0.0-alpha.57 to 1.0.0-alpha.66
- Updated @burnt-labs/constants from 0.1.0-alpha.15 to 0.1.0-alpha.18
- Updated @burnt-labs/ui from 0.1.0-alpha.7 to 0.1.0-alpha.17
- Added changeset file to document the package updates
- Updated .prettierignore to exclude .changeset directory
