### PR TITLE
DO-190: Fix for the ibc rpc call error

### DIFF
--- a/src/features/staking/lib/core/base.ts
+++ b/src/features/staking/lib/core/base.ts
@@ -97,21 +97,11 @@ export const getRewards = async (address: string, validatorAddress: string) => {
     validatorAddress,
   );
 
-  const rewardsData = await Promise.all(
-    rewards.rewards.map(async (reward) => {
-      if (reward.denom.indexOf("ibc/") == 0) {
-        const coin = await queryClient.ibc.transfer.denomTrace(
-          reward.denom.substring(4),
-        );
+  // Note: We skip IBC denom resolution since we only care about UXION rewards.
+  // The denomTrace query was removed in ibc-go v10 (used by Xion mainnet).
+  // IBC denoms like "ibc/..." won't match "UXION" and get filtered out below.
 
-        reward.denom = coin.denomTrace?.baseDenom || reward.denom;
-      }
-
-      return reward;
-    }),
-  );
-
-  return rewardsData
+  return rewards.rewards
     .filter((reward) => reward.denom?.toUpperCase() === "UXION")
     .map((reward) => ({
       amount: new BigNumber(reward.amount)


### PR DESCRIPTION
- Removed the Promise.all loop that called the broken denomTrace query
- Added a comment explaining why (ibc-go v10 removed the endpoint)
- Simplified the code to directly filter rewards.rewards

The logic is unchanged: IBC denoms (ibc/...) won't match "UXION" and get filtered out. The only difference is we no longer make a failing RPC call first.