### PR TITLE
ci: backport DO-302 v9 release helpers from oauth2-api-service

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,59 @@
+name: Bump version
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Bump package.json to match published release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Strip leading 'v' from tag (v0.0.2 -> 0.0.2)
+          VERSION="${RELEASE_TAG#v}"
+
+          # Only proceed if the tag is a clean MAJOR.MINOR.PATCH.
+          # Prereleases / build metadata are out of scope; the standard's
+          # release.yml only drafts clean M.M.P tags, so this should be a no-op
+          # for anything else (e.g. manually-published v1.0.0-rc.1).
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag '$RELEASE_TAG' is not a clean M.M.P version; skipping bump."
+            exit 0
+          fi
+
+          # Update package.json
+          node -e "const p=require('./package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n')"
+
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "package.json version is now: ${NEW_VERSION}"
+
+          # No-op if package.json was already at the target version (e.g. the
+          # release was published from a state where someone already bumped manually)
+          if git diff --quiet package.json; then
+            echo "package.json already at ${VERSION}; nothing to commit."
+            exit 0
+          fi
+
+          # Configure git as the github-actions bot
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # [skip ci] prevents the push from re-triggering merge-pr.yml
+          git add package.json
+          git commit -m "chore: bump package.json to ${VERSION} [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         id: version
         run: |
           CURRENT=$(node -p "require('./package.json').version")
-          NEXT=$(npx --yes semver "$CURRENT" -i patch)
+          NEXT=$(node -p "((v)=>{const m=v.match(/^(\d+)\.(\d+)\.(\d+)$/);if(!m)throw new Error('version not M.M.P: '+v);return [m[1],m[2],parseInt(m[3],10)+1].join('.')})(require('./package.json').version)")
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "tag=v$NEXT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

Two CI helpers were absorbed into the DO-302 v9 standard during the [xion-faucet migration](https://github.com/burnt-labs/oauth2-api-service) and aren't yet present in this repo. Since `xion-staking` is the reference / proof-of-standard repo, having the v9 shape land here closes the loop.

Both files are copied **verbatim** from `oauth2-api-service @ main` — no per-app divergence.

## Changes

### 1. `release.yml`: inline node patch-bump

Replaces:
```yaml
NEXT=$(npx --yes semver "$CURRENT" -i patch)
```
with an inline node M.M.P-regex + `parseInt+1`:
```yaml
NEXT=$(node -p "((v)=>{const m=v.match(/^(\d+)\.(\d+)\.(\d+)$/);if(!m)throw new Error('version not M.M.P: '+v);return [m[1],m[2],parseInt(m[3],10)+1].join('.')})(require('./package.json').version)")
```

- Removes the per-release network fetch of the `semver` package.
- Throws loudly on a malformed version (the previous form would silently return `undefined`-ish output if `semver` choked).
- Self-contained — no extra deps in the workflow.

### 2. `bump-version.yml` (new): post-publish `package.json` bump

Triggered on `release: published`. Strips the leading `v` from the tag, verifies it's a clean `M.M.P`, writes the new version into `package.json`, and pushes back to `main` as `github-actions[bot]` with `[skip ci]`.

**Why this matters:** without `bump-version.yml`, `release.yml` keeps computing `next = currentPatch + 1` against an unchanged `package.json`. After the first publish, the next dispatch tries to create the *same* tag, sees it already exists via `gh release view`, and silently skips drafting. The version chain effectively stalls.

The `[skip ci]` flag prevents the bump commit from re-triggering `merge-pr.yml`.

## Scope

- CI / release plumbing only. No runtime change.
- Doesn't touch any app code, `wrangler.jsonc`, or preview workflows.
- Independent of any other in-flight workflow PRs.

## Verification

- `release.yml`'s patch-bump path is exercised by every PR merge after this lands (next merge will draft a release with the inline-node version).
- `bump-version.yml` fires once a release is **published** (not just drafted), so it's only on the hot path during an actual mainnet release cut.