### PR TITLE
ci: backport DO-302 v6/v7 preview-URL surfacing + script-injection hardening to preview workflows

### DIFF
--- a/.github/workflows/preview-mainnet.yml
+++ b/.github/workflows/preview-mainnet.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   deployments: write
 
 jobs:
@@ -48,3 +48,54 @@ jobs:
 
           echo "version_id=${VERSION_ID:-unknown}" >> "$GITHUB_OUTPUT"
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+      - name: Surface preview URL on commit
+        if: steps.extract.outputs.preview_url != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `${{ steps.extract.outputs.preview_url }}`
+            const versionId = `${{ steps.extract.outputs.version_id }}`
+            const sha = context.sha
+            const marker = `<!-- mainnet-preview:${sha} -->`
+            core.info(`event: ${context.eventName}, sha: ${sha}, url: ${url}`)
+            const body = [
+              marker,
+              `### Mainnet preview ready`,
+              ``,
+              `- Preview: ${url}`,
+              `- Version: \`${versionId}\``,
+              ``,
+              `Versioned upload against mainnet bindings. Canonical \`staking.burnt.com\` traffic is unchanged until a GitHub Release is published.`,
+            ].join('\n')
+
+            try {
+              const { data: existing } = await github.rest.repos.listCommentsForCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+                per_page: 100,
+              })
+              core.info(`found ${existing.length} existing commit comments`)
+              const prev = existing.find((c) => c.body && c.body.includes(marker))
+              if (prev) {
+                core.info(`updating existing comment ${prev.id}`)
+                await github.rest.repos.updateCommitComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: prev.id,
+                  body,
+                })
+              } else {
+                core.info(`creating new commit comment`)
+                const { data: created } = await github.rest.repos.createCommitComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: sha,
+                  body,
+                })
+                core.info(`created comment ${created.id} at ${created.html_url}`)
+              }
+            } catch (err) {
+              core.warning(`commit-comment upsert failed: ${err.status} ${err.message}`)
+            }

--- a/.github/workflows/preview-mainnet.yml
+++ b/.github/workflows/preview-mainnet.yml
@@ -35,8 +35,9 @@ jobs:
           packageManager: pnpm
       - name: Extract version ID and preview URL
         id: extract
+        env:
+          OUTPUT: ${{ steps.preview.outputs.command-output }}
         run: |
-          OUTPUT='${{ steps.preview.outputs.command-output }}'
           VERSION_ID=$(echo "$OUTPUT" | grep -oP 'Version ID:\s+\K[a-f0-9-]+' || echo '')
           PREVIEW_URL=$(echo "$OUTPUT" | grep -oP 'https://[^\s]+\.workers\.dev[^\s]*' | head -1 || echo '')
 

--- a/.github/workflows/preview-testnet.yml
+++ b/.github/workflows/preview-testnet.yml
@@ -3,6 +3,7 @@ name: Preview Testnet
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   check:
@@ -27,8 +28,10 @@ jobs:
       name: preview-testnet
       url: ${{ steps.extract.outputs.preview_url }}
     permissions:
-      contents: read
+      contents: write
       deployments: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -63,3 +66,109 @@ jobs:
 
           echo "version_id=${VERSION_ID:-unknown}" >> "$GITHUB_OUTPUT"
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+      - name: Surface preview URL on commit and PR
+        if: steps.extract.outputs.preview_url != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `${{ steps.extract.outputs.preview_url }}`
+            const versionId = `${{ steps.extract.outputs.version_id }}`
+            const pr = context.payload.pull_request
+            const sha = pr?.head?.sha ?? context.sha
+            const marker = `<!-- testnet-preview:${sha} -->`
+            core.info(`event: ${context.eventName}, sha: ${sha}, pr: ${pr?.number ?? 'none'}, url: ${url}`)
+            const body = [
+              marker,
+              `### Testnet preview ready`,
+              ``,
+              `- Preview: ${url}`,
+              `- Version: \`${versionId}\``,
+              ``,
+              `Runs against testnet bindings (KV, env vars, secrets) on a versioned worker URL. Canonical \`staking.testnet.burnt.com\` traffic is unchanged until the PR merges.`,
+            ].join('\n')
+
+            async function upsertCommitComment(commitSha) {
+              core.info(`upsertCommitComment(${commitSha})`)
+              try {
+                const { data: existing } = await github.rest.repos.listCommentsForCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: commitSha,
+                  per_page: 100,
+                })
+                core.info(`  found ${existing.length} existing commit comments`)
+                const prev = existing.find((c) => c.body && c.body.includes(marker))
+                if (prev) {
+                  core.info(`  updating existing comment ${prev.id}`)
+                  await github.rest.repos.updateCommitComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: prev.id,
+                    body,
+                  })
+                } else {
+                  core.info(`  creating new commit comment`)
+                  const { data: created } = await github.rest.repos.createCommitComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    commit_sha: commitSha,
+                    body,
+                  })
+                  core.info(`  created comment ${created.id} at ${created.html_url}`)
+                }
+              } catch (err) {
+                core.warning(`upsertCommitComment failed: ${err.status} ${err.message}`)
+              }
+            }
+
+            async function upsertPrComment(prNumber) {
+              core.info(`upsertPrComment(${prNumber})`)
+              try {
+                const { data: existing } = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  per_page: 100,
+                })
+                core.info(`  found ${existing.length} existing PR comments`)
+                const prev = existing.find((c) => c.body && c.body.includes(marker))
+                if (prev) {
+                  core.info(`  updating existing comment ${prev.id}`)
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: prev.id,
+                    body,
+                  })
+                } else {
+                  core.info(`  creating new PR comment`)
+                  const { data: created } = await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body,
+                  })
+                  core.info(`  created comment ${created.id} at ${created.html_url}`)
+                }
+              } catch (err) {
+                core.warning(`upsertPrComment failed: ${err.status} ${err.message}`)
+              }
+            }
+
+            await upsertCommitComment(sha)
+
+            let prNumbers = []
+            if (pr) {
+              prNumbers = [pr.number]
+            } else {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              })
+              prNumbers = prs.filter((p) => p.state === 'open').map((p) => p.number)
+            }
+            for (const prNumber of prNumbers) {
+              await upsertPrComment(prNumber)
+            }

--- a/.github/workflows/preview-testnet.yml
+++ b/.github/workflows/preview-testnet.yml
@@ -46,12 +46,13 @@ jobs:
         with:
           apiToken: ${{ secrets.BURNT_CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.BURNT_CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --env testnet --message "PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
+          command: versions upload --env testnet --message "PR preview ${{ github.sha }}"
           packageManager: pnpm
       - name: Extract version ID and preview URL
         id: extract
+        env:
+          OUTPUT: ${{ steps.preview.outputs.command-output }}
         run: |
-          OUTPUT='${{ steps.preview.outputs.command-output }}'
           VERSION_ID=$(echo "$OUTPUT" | grep -oP 'Version ID:\s+\K[a-f0-9-]+' || echo '')
           PREVIEW_URL=$(echo "$OUTPUT" | grep -oP 'https://[^\s]+\.workers\.dev[^\s]*' | head -1 || echo '')
 


### PR DESCRIPTION
## Why

Brings the reference repo's preview workflows up to the v9 shape used by `oauth2-api-service` and `xion-faucet`. Two related concerns bundled because they touch the same two files:

1. **Script-injection hardening** — `${{ github.event.pull_request.title }}` interpolated into the wrangler `--message` arg, and `${{ steps.preview.outputs.command-output }}` interpolated into a shell single-quoted string. Both flagged by Copilot on `oauth2-api-service` PR #33; same patterns existed here.
2. **v6/v7 preview-URL surfacing** — idempotent commit-comment (and PR-comment, for testnet) per push, SHA-normalized, marker-keyed. The standard absorbed this during the `xion-faucet` migration but the reference repo predated the change.

This is the **second** of two follow-ups landing the v9 standard against this repo. The first is #61 (release helpers — independent files, no overlap).

## Commits

### `05da9f8` — ci: harden preview workflows against script injection

- `preview-testnet.yml`: replace `${{ github.event.pull_request.title }}` interpolation in the wrangler `--message` arg with `${{ github.sha }}` (fixed 40-char hex). An externally-authored PR title containing a double-quote or shell metacharacter could otherwise escape the message string and inject additional wrangler flags. Same pattern used by `oauth2-api-service` preview-mainnet + `xion-faucet` preview-testnet.
- Both `preview-testnet.yml` and `preview-mainnet.yml`: the `OUTPUT='${{ steps.preview.outputs.command-output }}'` single-quoted shell assignment is moved into an `env:` block on the step. A wrangler output containing a single quote would otherwise break out of the string and the remainder would be shell-interpreted.

CI-only hardening, no runtime change. The wrangler command still gets a versioned-upload message tied to the commit, and the extract step still parses the same fields out of the same output.

### `906b9a7` — ci: backport DO-302 v6/v7 preview-URL surfacing to preview workflows

What you get on each PR push:

- Preview-testnet uploads the versioned worker (unchanged).
- An idempotent comment is upserted on the **head commit** AND on **any open PR**, keyed by SHA via a hidden HTML marker (`<!-- testnet-preview:${sha} -->`). Force-pushes update the same comment in place rather than spamming a new one per push.
- The body includes the preview URL, the wrangler version ID, and a note that canonical `staking.testnet.burnt.com` traffic is unchanged until merge.

Preview-mainnet gets the **commit-comment half only** — it runs on `workflow_call` from `merge-pr.yml` after testnet auto-deploys, so there's no PR context to comment on, just the merge commit. Marker is `<!-- mainnet-preview:${sha} -->` so it doesn't collide with testnet.

Permissions widened:
- `preview-testnet` job: `contents/issues/pull-requests/deployments: write` (so `github-script` can upsert comments).
- `preview-mainnet` top-level: `contents/deployments: write` (commit comments only).

The `workflow_dispatch` trigger is added to `preview-testnet` to match the faucet/oauth2 shape — useful for re-running the preview against an arbitrary ref when debugging the surfacing path.

## Out of scope (intentionally)

- **v8 build-time env (GH Variables + `.env` writeup)** — `xion-staking` only has one build-time var (`NEXT_PUBLIC_CHAIN_ID`) and the existing inline-env approach is fine for that. The v8 pattern shines at ~15+ build vars like `xion-faucet`.
- **v9 Turnstile allowed-hostnames workaround** — staking doesn't use Turnstile.
- **Release helpers (`bump-version.yml`, inline-node patch-bump)** — in PR #61.

## Verification

- `preview-testnet.yml` change is exercised on this PR's own push: a `<!-- testnet-preview:${sha} -->` comment should appear on the head commit and on this PR.
- `preview-mainnet.yml` change is exercised on the merge commit once this lands. Idempotency can be re-verified by `workflow_dispatch`-ing the testnet preview against the head SHA — the comment should update, not duplicate.