### PR TITLE
chore(ci): adopt DO-302 v12 standard (release-gated both networks)

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -36,16 +36,20 @@ jobs:
             exit 0
           fi
 
-          # Downgrade guard: refuse to write if the published tag is less than
-          # the current package.json version. Catches the case where a stale
-          # draft (created before main advanced past a newer version) is
-          # published — without this guard, the bump would silently regress
+          # Downgrade guard: refuse to write if the published tag is strictly
+          # less than the current package.json version. Catches the case where
+          # a stale draft (created before main advanced past a newer version)
+          # is published — without this guard, the bump would silently regress
           # package.json and the next release.yml dispatch would stall on the
           # same tag via the gh-release-view "exists" short-circuit.
+          # DO-315: equality must fall through to the no-op block below
+          # (which logs correctly), so the comparison is strict less-than.
+          # Earlier cohort versions used GREATER which fired on both less-than
+          # AND equal-to, producing a misleading "stale draft" log on equality.
           CURRENT=$(node -p "require('./package.json').version")
-          GREATER=$(node -p "((a,b)=>{const pa=a.split('.').map(Number),pb=b.split('.').map(Number);for(let i=0;i<3;i++){if(pa[i]!==pb[i])return pa[i]>pb[i];}return false})('${VERSION}','${CURRENT}')")
-          if [ "$GREATER" != "true" ]; then
-            echo "Published tag '${VERSION}' is not strictly greater than current package.json version '${CURRENT}'; refusing to write. This usually means a stale draft was published after main moved forward."
+          LESS=$(node -p "((a,b)=>{const pa=a.split('.').map(Number),pb=b.split('.').map(Number);for(let i=0;i<3;i++){if(pa[i]!==pb[i])return pa[i]<pb[i];}return false})('${VERSION}','${CURRENT}')")
+          if [ "$LESS" = "true" ]; then
+            echo "Published tag '${VERSION}' is less than current package.json version '${CURRENT}'; refusing to write. This usually means a stale draft was published after main moved forward."
             exit 0
           fi
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -75,11 +75,23 @@ jobs:
           # is lost silently. Three attempts with rebase-on-failure handles
           # any realistic contention window (chore push, parallel devops push)
           # without making the job flaky.
+          PUSHED=false
           for attempt in 1 2 3; do
             if git push origin HEAD:main; then
+              PUSHED=true
               break
             fi
             echo "Push attempt ${attempt} failed; rebasing on origin/main and retrying"
             git fetch origin main
             git rebase origin/main || { echo "rebase failed; bailing"; exit 1; }
           done
+
+          # Fail loudly if all three attempts dropped the push. Without this,
+          # the workflow exits successfully while package.json on main is
+          # still at the pre-release version — the next release.yml run will
+          # then short-circuit on the gh-release-view "exists" check and the
+          # bump silently stalls forever.
+          if [ "$PUSHED" != "true" ]; then
+            echo "::error::All 3 push attempts failed after rebase; bump-version did not land on main."
+            exit 1
+          fi

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,85 @@
+name: Bump version
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Bump package.json to match published release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Strip leading 'v' from tag (v0.0.2 -> 0.0.2)
+          VERSION="${RELEASE_TAG#v}"
+
+          # Only proceed if the tag is a clean MAJOR.MINOR.PATCH.
+          # Prereleases / build metadata are out of scope; the standard's
+          # release.yml only drafts clean M.M.P tags, so this should be a no-op
+          # for anything else (e.g. manually-published v1.0.0-rc.1).
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag '$RELEASE_TAG' is not a clean M.M.P version; skipping bump."
+            exit 0
+          fi
+
+          # Downgrade guard: refuse to write if the published tag is less than
+          # the current package.json version. Catches the case where a stale
+          # draft (created before main advanced past a newer version) is
+          # published — without this guard, the bump would silently regress
+          # package.json and the next release.yml dispatch would stall on the
+          # same tag via the gh-release-view "exists" short-circuit.
+          CURRENT=$(node -p "require('./package.json').version")
+          GREATER=$(node -p "((a,b)=>{const pa=a.split('.').map(Number),pb=b.split('.').map(Number);for(let i=0;i<3;i++){if(pa[i]!==pb[i])return pa[i]>pb[i];}return false})('${VERSION}','${CURRENT}')")
+          if [ "$GREATER" != "true" ]; then
+            echo "Published tag '${VERSION}' is not strictly greater than current package.json version '${CURRENT}'; refusing to write. This usually means a stale draft was published after main moved forward."
+            exit 0
+          fi
+
+          # Update package.json
+          node -e "const p=require('./package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n')"
+
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "package.json version is now: ${NEW_VERSION}"
+
+          # No-op if package.json was already at the target version (e.g. the
+          # release was published from a state where someone already bumped manually)
+          if git diff --quiet package.json; then
+            echo "package.json already at ${VERSION}; nothing to commit."
+            exit 0
+          fi
+
+          # Configure git as the github-actions bot
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # [skip ci] prevents the push from re-triggering merge-pr.yml
+          git add package.json
+          git commit -m "chore: bump package.json to ${VERSION} [skip ci]"
+
+          # Retry on non-fast-forward push: if main receives any commit between
+          # the checkout step and this push, the bare push fails and the bump
+          # is lost silently. Three attempts with rebase-on-failure handles
+          # any realistic contention window (chore push, parallel devops push)
+          # without making the job flaky.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              break
+            fi
+            echo "Push attempt ${attempt} failed; rebasing on origin/main and retrying"
+            git fetch origin main
+            git rebase origin/main || { echo "rebase failed; bailing"; exit 1; }
+          done

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -1,7 +1,8 @@
 name: Deploy Testnet
 
 on:
-  workflow_call:
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -9,7 +10,21 @@ permissions:
   deployments: write
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm run type-check
+      - run: pnpm run test
+
   deploy-testnet:
+    needs: check
     runs-on: ubuntu-latest
     environment:
       name: testnet

--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -9,6 +9,8 @@ permissions:
   actions: read
   contents: write
   deployments: write
+  issues: write
+  pull-requests: write
 
 jobs:
   check:
@@ -25,17 +27,17 @@ jobs:
       - run: pnpm run type-check
       - run: pnpm run test
 
-  deploy-testnet:
+  preview-testnet:
     needs: check
-    uses: ./.github/workflows/deploy-testnet.yml
+    uses: ./.github/workflows/preview-testnet.yml
     secrets: inherit
 
   preview-mainnet:
-    needs: deploy-testnet
+    needs: check
     uses: ./.github/workflows/preview-mainnet.yml
     secrets: inherit
 
   release:
-    needs: preview-mainnet
+    needs: [preview-testnet, preview-mainnet]
     uses: ./.github/workflows/release.yml
     secrets: inherit

--- a/.github/workflows/preview-mainnet.yml
+++ b/.github/workflows/preview-mainnet.yml
@@ -1,15 +1,21 @@
 name: Preview Mainnet
 
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_call:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   deployments: write
+  issues: write
+  pull-requests: write
 
 jobs:
   preview-mainnet:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     environment:
       name: preview-mainnet
@@ -24,19 +30,32 @@ jobs:
       - name: Build mainnet app
         run: pnpm run build
         env:
-          NEXT_PUBLIC_CHAIN_ID: "xion-mainnet-1"
+          NEXT_PUBLIC_CHAIN_ID: ${{ vars.NEXT_PUBLIC_CHAIN_ID }}
+      - name: Compose preview message
+        id: msg
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ACTOR: ${{ github.actor }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            echo "msg=PR #${PR_NUMBER} by @${ACTOR} - ${SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "msg=Main HEAD ${SHA}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Upload mainnet preview version
         id: preview
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.BURNT_CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.BURNT_CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --env mainnet --message "Main preview ${{ github.sha }}"
+          command: versions upload --env mainnet --message "${{ steps.msg.outputs.msg }}"
           packageManager: pnpm
       - name: Extract version ID and preview URL
         id: extract
+        env:
+          OUTPUT: ${{ steps.preview.outputs.command-output }}
         run: |
-          OUTPUT='${{ steps.preview.outputs.command-output }}'
           VERSION_ID=$(echo "$OUTPUT" | grep -oP 'Version ID:\s+\K[a-f0-9-]+' || echo '')
           PREVIEW_URL=$(echo "$OUTPUT" | grep -oP 'https://[^\s]+\.workers\.dev[^\s]*' | head -1 || echo '')
 
@@ -47,3 +66,83 @@ jobs:
 
           echo "version_id=${VERSION_ID:-unknown}" >> "$GITHUB_OUTPUT"
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+      - name: Surface preview URL on commit and PR
+        if: steps.extract.outputs.preview_url != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `${{ steps.extract.outputs.preview_url }}`
+            const versionId = `${{ steps.extract.outputs.version_id }}`
+            const marker = `<!-- mainnet-preview:${context.sha} -->`
+            const body = [
+              marker,
+              `### Mainnet preview ready`,
+              ``,
+              `- Preview: ${url}`,
+              `- Version: \`${versionId}\``,
+              ``,
+              `Runs against live mainnet bindings on a versioned worker URL. Canonical \`staking.burnt.com\` traffic is unchanged until a release is published.`,
+            ].join('\n')
+
+            async function upsertCommitComment() {
+              const { data: existing } = await github.rest.repos.listCommentsForCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                per_page: 100,
+              })
+              const prev = existing.find((c) => c.body && c.body.includes(marker))
+              if (prev) {
+                await github.rest.repos.updateCommitComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: prev.id,
+                  body,
+                })
+              } else {
+                await github.rest.repos.createCommitComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: context.sha,
+                  body,
+                })
+              }
+            }
+
+            async function upsertPrComment(prNumber) {
+              const { data: existing } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              })
+              const prev = existing.find((c) => c.body && c.body.includes(marker))
+              if (prev) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: prev.id,
+                  body,
+                })
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                })
+              }
+            }
+
+            await upsertCommitComment()
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            })
+            for (const pr of prs) {
+              if (pr.state !== 'open') continue
+              await upsertPrComment(pr.number)
+            }

--- a/.github/workflows/preview-mainnet.yml
+++ b/.github/workflows/preview-mainnet.yml
@@ -15,7 +15,14 @@ permissions:
 
 jobs:
   preview-mainnet:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # Skip draft PRs (not ready for review) AND fork PRs (would run with
+    # mainnet secrets in scope from any forked branch — DO-315 fork-PR
+    # guard sweep). workflow_call from merge-pr.yml leaves pull_request
+    # context empty, so the first disjunct holds and the job runs.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     environment:
       name: preview-mainnet

--- a/.github/workflows/preview-mainnet.yml
+++ b/.github/workflows/preview-mainnet.yml
@@ -74,7 +74,14 @@ jobs:
           script: |
             const url = `${{ steps.extract.outputs.preview_url }}`
             const versionId = `${{ steps.extract.outputs.version_id }}`
-            const marker = `<!-- mainnet-preview:${context.sha} -->`
+
+            // On pull_request events, context.sha is the synthetic
+            // refs/pull/N/merge SHA. Prefer pull_request.head.sha so the
+            // marker keys off the SHA users see and the commit-comment
+            // API has a real target.
+            const pr = context.payload.pull_request
+            const sha = pr?.head?.sha ?? context.sha
+            const marker = `<!-- mainnet-preview:${sha} -->`
             const body = [
               marker,
               `### Mainnet preview ready`,
@@ -85,13 +92,16 @@ jobs:
               `Runs against live mainnet bindings on a versioned worker URL. Canonical \`staking.burnt.com\` traffic is unchanged until a release is published.`,
             ].join('\n')
 
-            async function upsertCommitComment() {
-              const { data: existing } = await github.rest.repos.listCommentsForCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: context.sha,
-                per_page: 100,
-              })
+            async function upsertCommitComment(commitSha) {
+              const existing = await github.paginate(
+                github.rest.repos.listCommentsForCommit,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: commitSha,
+                  per_page: 100,
+                },
+              )
               const prev = existing.find((c) => c.body && c.body.includes(marker))
               if (prev) {
                 await github.rest.repos.updateCommitComment({
@@ -104,19 +114,22 @@ jobs:
                 await github.rest.repos.createCommitComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  commit_sha: context.sha,
+                  commit_sha: commitSha,
                   body,
                 })
               }
             }
 
             async function upsertPrComment(prNumber) {
-              const { data: existing } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100,
-              })
+              const existing = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  per_page: 100,
+                },
+              )
               const prev = existing.find((c) => c.body && c.body.includes(marker))
               if (prev) {
                 await github.rest.issues.updateComment({
@@ -135,14 +148,19 @@ jobs:
               }
             }
 
-            await upsertCommitComment()
+            await upsertCommitComment(sha)
 
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            })
-            for (const pr of prs) {
-              if (pr.state !== 'open') continue
-              await upsertPrComment(pr.number)
+            let prNumbers = []
+            if (pr) {
+              prNumbers = [pr.number]
+            } else {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              })
+              prNumbers = prs.filter((p) => p.state === 'open').map((p) => p.number)
+            }
+            for (const prNumber of prNumbers) {
+              await upsertPrComment(prNumber)
             }

--- a/.github/workflows/preview-testnet.yml
+++ b/.github/workflows/preview-testnet.yml
@@ -9,8 +9,14 @@ on:
 
 jobs:
   check:
-    # Skip on draft PRs; runs unconditionally when called via workflow_call (no pull_request context).
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # Skip draft PRs AND fork PRs (DO-315 fork-PR guard sweep). Testnet
+    # secrets are lower-risk than mainnet, but symmetry keeps fork PRs from
+    # reaching any Burnt CI secrets at all. workflow_call (from merge-pr.yml)
+    # leaves pull_request context empty, so the first disjunct holds.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,7 +33,10 @@ jobs:
 
   preview-testnet:
     needs: check
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     environment:
       name: preview-testnet

--- a/.github/workflows/preview-testnet.yml
+++ b/.github/workflows/preview-testnet.yml
@@ -91,7 +91,14 @@ jobs:
           script: |
             const url = `${{ steps.extract.outputs.preview_url }}`
             const versionId = `${{ steps.extract.outputs.version_id }}`
-            const marker = `<!-- testnet-preview:${context.sha} -->`
+
+            // On pull_request events, context.sha is the synthetic
+            // refs/pull/N/merge SHA, not the actual head commit. Prefer
+            // pull_request.head.sha so the marker keys off the SHA users
+            // see and the commit-comment API has a real target.
+            const pr = context.payload.pull_request
+            const sha = pr?.head?.sha ?? context.sha
+            const marker = `<!-- testnet-preview:${sha} -->`
             const body = [
               marker,
               `### Testnet preview ready`,
@@ -102,13 +109,18 @@ jobs:
               `Runs against live testnet bindings on a versioned worker URL. Canonical \`staking.testnet.burnt.com\` traffic is unchanged until a release is published.`,
             ].join('\n')
 
-            async function upsertCommitComment() {
-              const { data: existing } = await github.rest.repos.listCommentsForCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: context.sha,
-                per_page: 100,
-              })
+            async function upsertCommitComment(commitSha) {
+              // Paginate past the per_page=100 cap so the marker lookup
+              // stays correct on hot commits.
+              const existing = await github.paginate(
+                github.rest.repos.listCommentsForCommit,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: commitSha,
+                  per_page: 100,
+                },
+              )
               const prev = existing.find((c) => c.body && c.body.includes(marker))
               if (prev) {
                 await github.rest.repos.updateCommitComment({
@@ -121,19 +133,24 @@ jobs:
                 await github.rest.repos.createCommitComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  commit_sha: context.sha,
+                  commit_sha: commitSha,
                   body,
                 })
               }
             }
 
             async function upsertPrComment(prNumber) {
-              const { data: existing } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100,
-              })
+              // Active PRs commonly exceed 100 comments; paginate so the
+              // marker-find stays reliable.
+              const existing = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  per_page: 100,
+                },
+              )
               const prev = existing.find((c) => c.body && c.body.includes(marker))
               if (prev) {
                 await github.rest.issues.updateComment({
@@ -152,14 +169,19 @@ jobs:
               }
             }
 
-            await upsertCommitComment()
+            await upsertCommitComment(sha)
 
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-            })
-            for (const pr of prs) {
-              if (pr.state !== 'open') continue
-              await upsertPrComment(pr.number)
+            let prNumbers = []
+            if (pr) {
+              prNumbers = [pr.number]
+            } else {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              })
+              prNumbers = prs.filter((p) => p.state === 'open').map((p) => p.number)
+            }
+            for (const prNumber of prNumbers) {
+              await upsertPrComment(prNumber)
             }

--- a/.github/workflows/preview-testnet.yml
+++ b/.github/workflows/preview-testnet.yml
@@ -3,9 +3,14 @@ name: Preview Testnet
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   check:
+    # Skip on draft PRs; runs unconditionally when called via workflow_call (no pull_request context).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,13 +27,16 @@ jobs:
 
   preview-testnet:
     needs: check
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     environment:
       name: preview-testnet
       url: ${{ steps.extract.outputs.preview_url }}
     permissions:
-      contents: read
+      contents: write
       deployments: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -40,18 +48,31 @@ jobs:
         run: pnpm run build
         env:
           NEXT_PUBLIC_CHAIN_ID: "xion-testnet-2"
+      - name: Compose preview message
+        id: msg
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ACTOR: ${{ github.actor }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            echo "msg=PR #${PR_NUMBER} by @${ACTOR} - ${SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "msg=Main HEAD ${SHA}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Upload testnet preview version
         id: preview
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.BURNT_CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.BURNT_CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --env testnet --message "PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
+          command: versions upload --env testnet --message "${{ steps.msg.outputs.msg }}"
           packageManager: pnpm
       - name: Extract version ID and preview URL
         id: extract
+        env:
+          OUTPUT: ${{ steps.preview.outputs.command-output }}
         run: |
-          OUTPUT='${{ steps.preview.outputs.command-output }}'
           VERSION_ID=$(echo "$OUTPUT" | grep -oP 'Version ID:\s+\K[a-f0-9-]+' || echo '')
           PREVIEW_URL=$(echo "$OUTPUT" | grep -oP 'https://[^\s]+\.workers\.dev[^\s]*' | head -1 || echo '')
 
@@ -62,3 +83,83 @@ jobs:
 
           echo "version_id=${VERSION_ID:-unknown}" >> "$GITHUB_OUTPUT"
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+      - name: Surface preview URL on commit and PR
+        if: steps.extract.outputs.preview_url != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `${{ steps.extract.outputs.preview_url }}`
+            const versionId = `${{ steps.extract.outputs.version_id }}`
+            const marker = `<!-- testnet-preview:${context.sha} -->`
+            const body = [
+              marker,
+              `### Testnet preview ready`,
+              ``,
+              `- Preview: ${url}`,
+              `- Version: \`${versionId}\``,
+              ``,
+              `Runs against live testnet bindings on a versioned worker URL. Canonical \`staking.testnet.burnt.com\` traffic is unchanged until a release is published.`,
+            ].join('\n')
+
+            async function upsertCommitComment() {
+              const { data: existing } = await github.rest.repos.listCommentsForCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                per_page: 100,
+              })
+              const prev = existing.find((c) => c.body && c.body.includes(marker))
+              if (prev) {
+                await github.rest.repos.updateCommitComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: prev.id,
+                  body,
+                })
+              } else {
+                await github.rest.repos.createCommitComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: context.sha,
+                  body,
+                })
+              }
+            }
+
+            async function upsertPrComment(prNumber) {
+              const { data: existing } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              })
+              const prev = existing.find((c) => c.body && c.body.includes(marker))
+              if (prev) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: prev.id,
+                  body,
+                })
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                })
+              }
+            }
+
+            await upsertCommitComment()
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            })
+            for (const pr of prs) {
+              if (pr.state !== 'open') continue
+              await upsertPrComment(pr.number)
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         id: version
         run: |
           CURRENT=$(node -p "require('./package.json').version")
-          NEXT=$(npx --yes semver "$CURRENT" -i patch)
+          NEXT=$(node -p "((v)=>{const m=v.match(/^(\d+)\.(\d+)\.(\d+)$/);if(!m)throw new Error('version not M.M.P: '+v);return [m[1],m[2],parseInt(m[3],10)+1].join('.')})(require('./package.json').version)")
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "tag=v$NEXT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Reshapes xion-staking's CI/CD to the [DO-302 v12 standard](../../onboarding/do-302/do-302-standard.md): release publish becomes the **single human gate** for both testnet AND mainnet (previously merge auto-deployed testnet; only mainnet was release-gated).

Rationale: under v11, merging to main flipped `staking.testnet.burnt.com` live without a human gate — same shape as any other Shape A repo. v12 applies the standard's own "human gates are explicit, merging is not a gate" principle uniformly. Both networks now promote from the same release artifact, simultaneously. See `do-302-standard.md` §"Changes from v11 → v12" for the full rationale.

## Pipeline shape (v12)

```
PR opened/synced      → preview-testnet + preview-mainnet (versioned uploads, ephemeral URLs)
merge to main         → preview-testnet-from-main + preview-mainnet-from-main + release-draft
release published     → deploy-testnet + deploy-mainnet (both live route flips, simultaneous)
```

Clicking Publish Release is the single human gate. Both networks promote from the same artifact validated on the preview URLs.

## What changed

- `merge-pr.yml` — no longer calls `deploy-testnet.yml`. Now calls `preview-testnet.yml` + `preview-mainnet.yml` from main HEAD, then `release.yml` to draft the next patch release.
- `preview-testnet.yml` — added `workflow_call` + `workflow_dispatch` triggers (callable from `merge-pr.yml`). Draft PRs skipped via `pull_request.draft == false`. Added v6/v7 commit + PR comment upserting.
- `preview-mainnet.yml` — added `pull_request` trigger so it fires at PR time alongside `preview-testnet.yml`. Same draft-skip + comment upserting.
- `deploy-testnet.yml` — trigger changed from `workflow_call` to `release: types: [published]`. Added `check` job (mirrors `deploy-mainnet.yml`).
- `release.yml` — `npx --yes semver` replaced with inline-node M.M.P regex + `parseInt+1`. Removes the per-release network fetch and throws loudly on malformed versions.
- `bump-version.yml` (NEW) — fires on `release: published`. v10-hardened with:
  - **Downgrade guard**: inline node M.M.P compare on published tag vs current `package.json`. Refuses to write if not strictly greater. Catches the stale-draft-published-after-main-moved case.
  - **Non-ff push retry**: 3-attempt loop with `git fetch + git rebase origin/main` between attempts. Handles parallel commit windows without making the job flaky.
- Script-injection hardening on preview workflows: `${{ pull_request.title }}` interpolation replaced with `${{ github.sha }}` in wrangler `--message`; `OUTPUT='${{ ... }}'` single-quoted shell assignment moved into `env:` blocks.

## Supersedes (now closed)

- #61 — v9 helpers backport (bump-version.yml + release.yml inline-node). Content preserved verbatim.
- #62 — preview-workflow hardening (script-injection + v6/v7 surfacing). Content preserved.

## What stayed the same

- `deploy-mainnet.yml` — unchanged.
- All worker names, environment names, route blocks, KV namespace IDs.
- Build env vars (`NEXT_PUBLIC_CHAIN_ID`) — testnet hardcoded to `"xion-testnet-2"`, mainnet uses `${{ vars.NEXT_PUBLIC_CHAIN_ID }}`. Pre-existing asymmetry; not changing it here.

## Required out-of-band setup before first release publish

1. **GH Environments** — add required-reviewer protection rule to `testnet` environment (was unprotected under v11). The `mainnet` environment protection stays.
2. **No worker-side changes required** — same wrangler config, same routes, same bindings.
3. **CF Workers Builds** — verify Git integration stays disconnected (was disconnected during original v11 migration).

## Verification (post-merge)

1. Merge fires `merge-pr.yml`: check + preview-testnet-from-main + preview-mainnet-from-main + release-draft. Verify two preview URLs surface in commit comments.
2. Publish the draft release that `release.yml` produced.
3. Verify both `deploy-testnet.yml` and `deploy-mainnet.yml` fire on the release event. Confirm `staking.testnet.burnt.com` and `staking.burnt.com` both serve the new artifact.
4. Subsequent merge → confirm `bump-version.yml` fires on next release-publish and `package.json` advances.

## Related

- DO-302 standard doc rev'd to v12 (`~/src/burnt/onboarding/do-302/do-302-standard.md`)
- [DO-310](https://linear.app/burnt/issue/DO-310) — v10 hardening absorbed; ticket commented + will close when this PR + the oauth2-api-service v12 reshape + DO-292 template reshape all merge

Refs DO-302.
