### PR TITLE
chore: reconcile package.json version to published v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xion-staking",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "pnpm": {


### PR DESCRIPTION
## What

Bumps `package.json` from `0.2.0` → `0.2.1` to match the published Latest release `v0.2.1`.

## Why

`v0.2.1` was hand-published (2026-05-05) **before** this repo had the DO-302 v12 `bump-version.yml` flow (introduced in #63), so `package.json` was never synced. With `package.json` at `0.2.0`, the `release.yml` draft step computes `NEXT = patch(0.2.0) = v0.2.1`, sees that release already exists, and no-ops — so the release flow can **never draft a new version** (verified on the #63 merge run: the `draft-release` job skipped).

Reconciling `package.json` to the published `v0.2.1` unwedges the chain: the next merge computes `v0.2.2` and drafts cleanly.

## Effect

Source-of-truth version only — **nothing is published or deployed** by this change. Refs DO-302.